### PR TITLE
feat: Add Pushover sounds to errors and filled orders

### DIFF
--- a/exchanges/kucoin.go
+++ b/exchanges/kucoin.go
@@ -109,7 +109,7 @@ func (self *Kucoin) error(err error, level int64, service model.Notify) {
 
 	if service != nil {
 		if notify.CanSend(level, notify.ERROR) {
-			err := service.SendMessage(msg, "Kucoin - ERROR")
+			err := service.SendMessage("intermission:::" + msg, "Kucoin - ERROR")
 			if err != nil {
 				log.Printf("[ERROR] %v", err)
 			}
@@ -434,7 +434,9 @@ func (self *Kucoin) sell(
 				if notify.CanSend(level, notify.FILLED) {
 					if service != nil {
 						title := fmt.Sprintf("Kucoin - Done %s", model.FormatOrderSide(side))
+						sound := "bugle:::"
 						if side == model.SELL {
+							sound = "cashregister:::"
 							if strategy == model.STRATEGY_STOP_LOSS {
 								perc := (mult - 1) * 100
 								if order.Stop == "loss" {
@@ -443,7 +445,7 @@ func (self *Kucoin) sell(
 								title = fmt.Sprintf("%s %.2f%%", title, perc)
 							}
 						}
-						if err = service.SendMessage(string(data), title); err != nil {
+						if err = service.SendMessage(sound + string(data), title); err != nil {
 							log.Printf("[ERROR] %v", err)
 						}
 					}

--- a/notify/pushover.go
+++ b/notify/pushover.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/gregdel/pushover"
 	"github.com/svanas/nefertiti/flag"
@@ -78,6 +79,10 @@ func (this *Pushover) SendMessage(message, title string) error {
 	app := pushover.New(this.appKey)
 	rec := pushover.NewRecipient(this.userKey)
 	msg := pushover.NewMessageWithTitle(message, title)
+	if result := strings.SplitN(message, ":::", 2); len(result) > 1 {
+		msg.Sound = result[0]
+		msg.Message = result[1]
+	}
 	_, err := app.SendMessage(msg, rec)
 	return err
 }


### PR DESCRIPTION
Currently for KUCN only

- `intermission` for errors
- `bugle` for filled buy orders
- `cashregister` for filled sell orders