### PR TITLE
feat: Add `--bag` option to hold profits

### DIFF
--- a/command/sell.go
+++ b/command/sell.go
@@ -124,6 +124,7 @@ Options:
   --notify   = [0|1|2|3] (see below)
   --mult     = multiplier, for example: 1.05 (aka 5 percent, optional)
   --hold     = name of the market not to sell, for example: BTC-EUR (optional)
+  --bag      = sell only enough 'base' at 'mult' to break even; hold the rest
 
 Strategy:
   0 = Standard. No trailing. No stop-loss. Recommended, default strategy.

--- a/exchanges/bittrex.go
+++ b/exchanges/bittrex.go
@@ -514,7 +514,14 @@ func (self *Bittrex) sell(
 					if err == nil {
 						var prec int
 						if prec, err = self.GetPricePrec(client, order.MarketName()); err == nil {
-							qty := self.GetMaxSize(client, base, quote, hold.HasMarket(order.MarketName()), order.QuantityFilled())
+							amount := order.QuantityFilled()
+							// only sell to break even and bag the remaining amount
+							if flag.Exists("bag") {
+								sp,_ := self.GetSizePrec(client, order.MarketName())
+								amount = pricing.FloorToPrecision(order.QuantityFilled() / mult, sp)
+								log.Printf("[INFO] Sell %f to BE", amount)
+							}
+							qty := self.GetMaxSize(client, base, quote, hold.HasMarket(order.MarketName()), amount)
 							if qty > 0 {
 								tgt := pricing.Multiply(order.Price(), mult, prec)
 								if strategy == model.STRATEGY_STOP_LOSS {

--- a/exchanges/gdax.go
+++ b/exchanges/gdax.go
@@ -465,6 +465,13 @@ func (self *Gdax) sell(
 							}
 
 							qty := old.Size
+							// only sell to break even and bag the remaining amount
+							if flag.Exists("bag") {
+								sp,_ := self.GetSizePrec(client, msg.ProductId)
+								qty = pricing.FloorToPrecision(old.Size / model.GetMult(), sp)
+								log.Printf("[INFO] Sell %f to BE", qty)
+							}
+
 							if qty == 0 {
 								if qty, err = self.getMinOrderSize(client, msg.ProductId); err != nil {
 									self.error(err, notify.Level(), service)

--- a/exchanges/kucoin.go
+++ b/exchanges/kucoin.go
@@ -500,6 +500,12 @@ func (self *Kucoin) sell(
 		if sp, err = self.GetSizePrec(client, symbol); err != nil {
 			return new, err
 		} else {
+			// only sell to break even and bag the remaining amount
+			if flag.Exists("bag") {
+				amount = amount / mult
+				log.Printf("[INFO] Sell %f to BE", amount)
+			}
+
 			amount = pricing.FloorToPrecision(amount, sp)
 		}
 


### PR DESCRIPTION
Instead of selling all of a filled order to make profit,
sell only enough to break even and leave the profit in "free coins"