### PR TITLE
chore: Setup for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Binaries for programs and plugins
+nefertiti
 *.exe
 *.exe~
 *.dll

--- a/main.go
+++ b/main.go
@@ -18,10 +18,11 @@ import (
 
 const (
 	APP_NAME    = "nefertiti"
-	APP_VERSION = "0.0.154"
 )
 
 var (
+	GitSummary string = "0.0.154"
+	APP_VERSION = strings.TrimPrefix(GitSummary, "v")
 	console *cli.CLI
 	port    int64 = 38700
 )


### PR DESCRIPTION
- Update version when using `govvv build`
- Ignore output binary