### PR TITLE
Feat/show trades profits

### DIFF
--- a/command/trades.go
+++ b/command/trades.go
@@ -1,0 +1,106 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/svanas/nefertiti/errors"
+	"github.com/svanas/nefertiti/exchanges"
+	"github.com/svanas/nefertiti/flag"
+	"github.com/svanas/nefertiti/model"
+)
+
+type (
+	TradesCommand struct {
+		*CommandMeta
+	}
+)
+
+func (c *TradesCommand) Run(args []string) int {
+	var (
+		err error
+		flg *flag.Flag
+	)
+
+	var exchange model.Exchange
+	if exchange, err = exchanges.GetExchange(); err != nil {
+		return c.ReturnError(err)
+	}
+
+	flg = flag.Get("side")
+	if !flg.Exists {
+		return c.ReturnError(errors.New("missing argument: side"))
+	}
+	side := model.NewOrderSide(flg.String())
+	if side == model.ORDER_SIDE_NONE {
+		return c.ReturnError(errors.Errorf("side %v is invalid", flg))
+	}
+
+	var date time.Time
+	flg = flag.Get("date")
+	if !flg.Exists {
+		date = time.Now()
+	} else if strings.ToLower(flg.String()) == "all" {
+		date = time.Time{}
+	} else if strings.ToLower(flg.String()) == "y" {
+		date = time.Now().AddDate(0, 0, -1)
+	} else {
+		date, err = time.Parse("2006-01-02", flg.String())
+		if err != nil {
+			return c.ReturnError(err)
+		}
+	}
+
+	var verbose = false
+	flg = flag.Get("verbose")
+	if flg.Exists {
+		verbose = true
+	}
+
+	var kind model.OrderType = model.LIMIT
+	flg = flag.Get("type")
+	if flg.Exists {
+		kind = model.NewOrderType(flg.String())
+		if kind == model.ORDER_TYPE_NONE {
+			return c.ReturnError(errors.Errorf("type %v is invalid", flg))
+		}
+	}
+
+	var market string
+	if market, err = model.GetMarket(exchange); err != nil {
+		return c.ReturnError(err)
+	}
+
+	var client interface{}
+	if client, err = exchange.GetClient(model.PRIVATE, flag.Sandbox()); err != nil {
+		return c.ReturnError(err)
+	}
+
+	return 0
+}
+
+func (c *TradesCommand) Help() string {
+	text := `
+Usage: ./nefertiti trades [options]
+
+The trades command shows information about trades done with the specified exchange.
+NOTE:
+  Command is work in progress! Not everything works as described here, yet!
+  The feature set might change (i.e. selecting weeks/month/year with --date)
+  The date argument does not care about timezones (planned!).
+
+Options:
+  --exchange = name (currently Binance only!)
+  --side     = [buy|sell] (Not used ATM)
+  --market   = selects the market pair for which the info is queried
+  --quote    = (NOT IMPLEMENTED YET) selects the markets by base currency
+  --date     = the day of interest. Either 'Y' for yesterday or "YYYY-MM-DD". Default: Today
+  --verbose  = show more detailed info
+`
+	return strings.TrimSpace(text)
+}
+
+func (c *TradesCommand) Synopsis() string {
+	return "Query information about your trades."
+}

--- a/main.go
+++ b/main.go
@@ -62,6 +62,9 @@ func main() {
 		"order": func() (cli.Command, error) {
 			return &command.OrderCommand{CommandMeta: &cm}, nil
 		},
+		"trades": func() (cli.Command, error) {
+			return &command.TradesCommand{CommandMeta: &cm}, nil
+		},
 		"book": func() (cli.Command, error) {
 			return &command.BookCommand{CommandMeta: &cm}, nil
 		},

--- a/model/order.go
+++ b/model/order.go
@@ -77,6 +77,8 @@ type (
 		Size      float64   `json:"size"`
 		Price     float64   `json:"price"`
 		CreatedAt time.Time `json:"createdAt"`
+		UpdatedAt time.Time `json:"updatedAt"`
+		BoughtAt  float64   `json:"boughtAt"`
 	}
 	Orders []Order
 )


### PR DESCRIPTION
Here is an idea which could be added (and improved) to NEF. Implemented for Binance only.
The purpose of it was to use it in a daily in a cronjob to generate data of the profits made. Some quick additions were made to make it useful from the commandline (here is of course much potential for improvment).
Querying Binance for all made orders/trades is expansive in regardss to API costs. as the API doesn't offer it. I my R scripts I just query ALL markets for a given base currency.

Some things I want to point you to:
- in binance/client.go: the Orders function does now query every trade not only the last 500/1000(?). This has an impact of the rest of the NEF code.
- the commands name "trades" is more or less a working title. I am open for discussing it
